### PR TITLE
Wireshark plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ heapsan breaks ntdll memory allocations from a process and add padding before & 
 cd icebox/bin/$ARCH/
 ./heapsan <vm_name> <process_name>
 ```
+
+<u>**wireshark:**</u><br>
+wireshark breaks when ndis driver reads or sends network packets and creates a wireshark trace (.pcapng). Each packet sent is associated to a callstack from kernel land to userland if necessary.
+
+```
+cd icebox/bin/$ARCH/
+./wireshark <name> <path_to_capture_file>
+```

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -161,6 +161,7 @@ foreach(sample IN ITEMS
     heapsan
     nt_writefile
     vm_resume
+    wireshark
 )
     add_target(${sample} samples "${root_dir}/src/icebox/samples/${sample}" OPTIONS executable fmt tidy)
     set_target_output_directory(${sample} "")

--- a/doc/BUILD.gen.md
+++ b/doc/BUILD.gen.md
@@ -152,6 +152,8 @@ cp %QT_DIR%/qtbase/bin/Qt5Gui.dll .
 cp %QT_DIR%/qtbase/bin/Qt5Widgets.dll .
 cp %QT_DIR%/qtbase/bin/Qt5OpenGL.dll .
 cp %QT_DIR%/qtbase/bin/Qt5PrintSupport.dll .
+mkdir platforms
+cp -r %QT_DIR%/qtbase/plugins/platforms/*.dll platforms
 cp %OPENSSL_DIR%/bin/libcrypto-1_1-x64.dll .
 cp %OPENSSL_DIR%/bin/libssl-1_1-x64.dll .
 cp %CURL_DIR%/builds/libcurl-vc10-x64-release-dll-ipv6-sspi-winssl/libcurl.dll .

--- a/src/icebox/icebox/callstack.hpp
+++ b/src/icebox/icebox/callstack.hpp
@@ -26,7 +26,7 @@ namespace callstack
         virtual ~ICallstack() = default;
 
         virtual bool    get_callstack               (proc_t proc, on_callstep_fn on_callstep) = 0;
-        virtual bool    get_callstack_from_context  (proc_t proc, const callstack::context_t& first, flags_e flag, on_callstep_fn on_callstep) = 0;
+        virtual bool    get_callstack_from_context  (proc_t proc, const context_t& first, flags_e flag, on_callstep_fn on_callstep) = 0;
     };
 
     std::shared_ptr<ICallstack> make_callstack_nt(core::Core& core);

--- a/src/icebox/icebox/callstack.hpp
+++ b/src/icebox/icebox/callstack.hpp
@@ -7,6 +7,14 @@ namespace core { struct Core; }
 
 namespace callstack
 {
+    struct context_t
+    {
+        uint64_t ip; // instruction pointer
+        uint64_t sp; // stack pointer
+        uint64_t bp; // base pointer
+        uint64_t cs; // code segment
+    };
+
     struct callstep_t
     {
         uint64_t addr;
@@ -17,7 +25,8 @@ namespace callstack
     {
         virtual ~ICallstack() = default;
 
-        virtual bool get_callstack(proc_t proc, on_callstep_fn on_callstep) = 0;
+        virtual bool    get_callstack               (proc_t proc, on_callstep_fn on_callstep) = 0;
+        virtual bool    get_callstack_from_context  (proc_t proc, const callstack::context_t& first, flags_e flag, on_callstep_fn on_callstep) = 0;
     };
 
     std::shared_ptr<ICallstack> make_callstack_nt(core::Core& core);

--- a/src/icebox/icebox/nt/callstack_nt.cpp
+++ b/src/icebox/icebox/nt/callstack_nt.cpp
@@ -422,7 +422,7 @@ namespace
         for(size_t i = 0; i < max_cs_depth; ++i)
         {
             opt<std::string> name;
-            opt<span_t>      span;
+            opt<span_t> span = {};
             // Get module from address
             if(c.core_.os->is_kernel_address(ctx.ip))
             {

--- a/src/icebox/icebox/nt/nt_types.hpp
+++ b/src/icebox/icebox/nt/nt_types.hpp
@@ -112,4 +112,50 @@ namespace nt_types
     };
     const char*                 page_access_str (PAGE_ACCESS arg);
     std::vector<const char*>    page_access_all (uint32_t arg);
+
+#define WOW64_SIZE_OF_80387_REGISTERS       80
+#define WOW64_MAXIMUM_SUPPORTED_EXTENSION   512
+
+    struct _WOW64_FLOATING_SAVE_AREA
+    {
+        uint32_t ControlWord;
+        uint32_t StatusWord;
+        uint32_t TagWord;
+        uint32_t ErrorOffset;
+        uint32_t ErrorSelector;
+        uint32_t DataOffset;
+        uint32_t DataSelector;
+        uint8_t  RegisterArea[WOW64_SIZE_OF_80387_REGISTERS];
+        uint32_t Cr0NpxState;
+    };
+
+    struct _WOW64_CONTEXT
+    {
+        uint32_t                  ContextFlags;
+        uint32_t                  Dr0;
+        uint32_t                  Dr1;
+        uint32_t                  Dr2;
+        uint32_t                  Dr3;
+        uint32_t                  Dr6;
+        uint32_t                  Dr7;
+        _WOW64_FLOATING_SAVE_AREA FloatSave;
+        uint32_t                  SegGs;
+        uint32_t                  SegFs;
+        uint32_t                  SegEs;
+        uint32_t                  SegDs;
+        uint32_t                  Edi;
+        uint32_t                  Esi;
+        uint32_t                  Ebx;
+        uint32_t                  Edx;
+        uint32_t                  Ecx;
+        uint32_t                  Eax;
+        uint32_t                  Ebp;
+        uint32_t                  Eip;
+        uint32_t                  SegCs;
+        uint32_t                  EFlags;
+        uint32_t                  Esp;
+        uint32_t                  SegSs;
+        uint8_t                   ExtendedRegisters[WOW64_MAXIMUM_SUPPORTED_EXTENSION];
+    };
+
 } // namespace nt_types

--- a/src/icebox/icebox/plugins/sym_loader.cpp
+++ b/src/icebox/icebox/plugins/sym_loader.cpp
@@ -13,6 +13,7 @@
 struct sym::Loader::Data
 {
     Data(core::Core& core, proc_t proc);
+    Data(core::Core& core);
 
     core::Core&          core;
     sym::Symbols         symbols;
@@ -20,6 +21,7 @@ struct sym::Loader::Data
     std::vector<uint8_t> buffer;
     reader::Reader       reader;
     opt<size_t>          mod_listen;
+    opt<size_t>          drv_listen;
 };
 
 namespace
@@ -37,6 +39,18 @@ namespace
         return read;
     }
 
+    static bool load_span_named(Data& d, const span_t& span, const std::string& name)
+    {
+        LOG(INFO, "{} loaded at {:x}:{:x}", name, span.addr, span.addr + span.size);
+        const auto loaded = load_module_buffer(d, span);
+        if(!loaded)
+            return false;
+
+        const auto filename = path::filename(name).replace_extension();
+        const auto inserted = d.symbols.insert(filename.generic_string(), span, &d.buffer[0], d.buffer.size());
+        return inserted;
+    }
+
     static bool load_module_named(Data& d, mod_t mod, const std::string& name)
     {
         LOG(INFO, "loading module {}", name);
@@ -44,17 +58,20 @@ namespace
         if(!span)
             return false;
 
-        LOG(INFO, "{} loaded at {:x}:{:x}", name, span->addr, span->addr + span->size);
-        const auto loaded = load_module_buffer(d, *span);
-        if(!loaded)
-            return false;
-
-        const auto filename = path::filename(name).replace_extension();
-        const auto inserted = d.symbols.insert(filename.generic_string(), *span, &d.buffer[0], d.buffer.size());
-        return inserted;
+        return load_span_named(d, *span, name);
     }
 
-    static bool load_module(Data& d, mod_t mod, const sym::predicate_fn& predicate)
+    static bool load_driver_named(Data& d, driver_t drv, const std::string& name)
+    {
+        LOG(INFO, "loading driver {}", name);
+        const auto span = d.core.os->driver_span(drv);
+        if(!span)
+            return false;
+
+        return load_span_named(d, *span, name);
+    }
+
+    static bool load_module(Data& d, mod_t mod, const sym::mod_predicate_fn& predicate)
     {
         const auto name = d.core.os->mod_name(d.proc, mod);
         if(!name)
@@ -69,6 +86,20 @@ namespace
 
         return true;
     }
+
+    static void load_driver(Data& d, driver_t drv, const sym::drv_predicate_fn& predicate)
+    {
+        const auto name = d.core.os->driver_name(drv);
+        if(!name)
+            return;
+
+        if(!predicate(drv, *name))
+            return;
+
+        const auto loaded = load_driver_named(d, drv, *name);
+        if(!loaded)
+            LOG(ERROR, "unable to load symbols from {}", *name);
+    }
 }
 
 Data::Data(core::Core& core, proc_t proc)
@@ -78,12 +109,24 @@ Data::Data(core::Core& core, proc_t proc)
 {
 }
 
+Data::Data(core::Core& core)
+    : core(core)
+    , proc({})
+    , reader(reader::make(core))
+{
+}
+
 sym::Loader::Loader(core::Core& core, proc_t proc)
     : d_(std::make_unique<Data>(core, proc))
 {
 }
 
-void sym::Loader::mod_listen(sym::predicate_fn predicate)
+sym::Loader::Loader(core::Core& core)
+    : d_(std::make_unique<Data>(core))
+{
+}
+
+void sym::Loader::mod_listen(sym::mod_predicate_fn predicate)
 {
     auto& d = *d_;
     d.core.os->mod_list(d.proc, [&](mod_t mod)
@@ -105,11 +148,38 @@ void sym::Loader::mod_listen()
     mod_listen([](mod_t, const std::string&) { return true; });
 }
 
+void sym::Loader::drv_listen(sym::drv_predicate_fn predicate)
+{
+    auto& d = *d_;
+    d.core.os->driver_list([&](driver_t drv)
+    {
+        load_driver(d, drv, predicate);
+        return WALK_NEXT;
+    });
+    d.drv_listen = d.core.os->listen_drv_create([=](driver_t drv, bool load)
+    {
+        if(load)
+            load_driver(*d_, drv, predicate);
+        else
+        {
+            // driver unloading todo...
+        }
+    });
+}
+
+void sym::Loader::drv_listen()
+{
+    drv_listen([](driver_t, const std::string&) { return true; });
+}
+
 sym::Loader::~Loader()
 {
     auto& d = *d_;
     if(d.mod_listen)
         d.core.os->unlisten(*d.mod_listen);
+
+    if(d.drv_listen)
+        d.core.os->unlisten(*d.drv_listen);
 }
 
 bool sym::Loader::load(mod_t mod)

--- a/src/icebox/icebox/plugins/sym_loader.hpp
+++ b/src/icebox/icebox/plugins/sym_loader.hpp
@@ -17,7 +17,7 @@ namespace sym
     {
         Loader(core::Core& core, proc_t proc);
 
-        // Loader initizialied without proc will load the drivers pdb
+        // Loader without proc will load the drivers pdb
          Loader(core::Core& core);
         ~Loader();
 

--- a/src/icebox/icebox/plugins/sym_loader.hpp
+++ b/src/icebox/icebox/plugins/sym_loader.hpp
@@ -10,15 +10,21 @@ namespace sym { struct Symbols; }
 
 namespace sym
 {
-    using predicate_fn = std::function<bool(mod_t, const std::string&)>;
+    using mod_predicate_fn = std::function<bool(mod_t, const std::string&)>;
+    using drv_predicate_fn = std::function<bool(driver_t, const std::string&)>;
 
     struct Loader
     {
-         Loader(core::Core& core, proc_t proc);
+        Loader(core::Core& core, proc_t proc);
+
+        // Loader initizialied without proc will load the drivers pdb
+         Loader(core::Core& core);
         ~Loader();
 
         void            mod_listen  ();
-        void            mod_listen  (predicate_fn predicate);
+        void            mod_listen  (mod_predicate_fn predicate);
+        void            drv_listen  ();
+        void            drv_listen  (drv_predicate_fn predicate);
         bool            load        (mod_t mod);
         sym::Symbols&   symbols     ();
 

--- a/src/icebox/samples/wireshark/main.cpp
+++ b/src/icebox/samples/wireshark/main.cpp
@@ -368,7 +368,7 @@ int main(int argc, char** argv)
 {
     logg::init(argc, argv);
     if(argc != 3)
-        return FAIL(-1, "usage: wireshark <name> <cpature file path>");
+        return FAIL(-1, "usage: wireshark <name> <path_to_capture_file>");
 
     const auto name = std::string{argv[1]};
     LOG(INFO, "starting on: {}", name.data());

--- a/src/icebox/samples/wireshark/main.cpp
+++ b/src/icebox/samples/wireshark/main.cpp
@@ -1,0 +1,281 @@
+#define FDP_MODULE "wireshark"
+#include "pcap.hpp"
+#include <icebox/callstack.hpp>
+#include <icebox/core.hpp>
+#include <icebox/log.hpp>
+#include <icebox/os.hpp>
+#include <icebox/plugins/sym_loader.hpp>
+#include <icebox/reader.hpp>
+#include <icebox/utils/fnview.hpp>
+#include <icebox/utils/path.hpp>
+#include <icebox/utils/pe.hpp>
+#include <map>
+#include <thread>
+
+namespace
+{
+
+    typedef struct _MDL
+    {
+        struct _MDL* Next;
+        uint16_t     Size;
+        uint16_t     MdlFlags;
+        void*        Process;
+        void* MappedSystemVa; /* see creators for field size annotations. */
+        void* StartVa;        /* see creators for validity; could be address 0.  */
+        uint32_t ByteCount;
+        uint32_t ByteOffset;
+    } MDL, *PMDL;
+
+    typedef struct _NET_BUFFER* PNET_BUFFER;
+
+    typedef struct _NET_BUFFER
+    {
+        PNET_BUFFER Next;
+        PMDL        CurrentMdl;
+        uint32_t    CurrentMdlOffset;
+        uint32_t    reserved;
+        uint32_t    stDataLength;
+        PMDL        MdlChain;
+        uint32_t    DataOffset;
+    } NET_BUFFER, *PNET_BUFFER;
+
+    typedef struct _NET_BUFFER_LIST* PNET_BUFFER_LIST;
+
+    typedef struct _NET_BUFFER_LIST
+    {
+        PNET_BUFFER_LIST Next;           // Next NetBufferList in the chain
+        PNET_BUFFER      FirstNetBuffer; // First NetBuffer on this NetBufferList
+        void*            Context;
+        PNET_BUFFER_LIST ParentNetBufferList;
+        void*            NdisPoolHandle;
+        void*            NdisReserved[2];
+        void*            ProtocolReserved[4];
+        void*            MiniportReserved[2];
+        void*            Scratch;
+        void*            SourceHandle;
+        uint32_t         NblFlags;       // public flags
+        int32_t          ChildRefCount;
+        uint32_t         Flags;          // private flags used by NDIs, protocols, miniport, etc.
+        union
+        {
+            uint32_t Status;
+            uint32_t NdisReserved2;
+        };
+    } NET_BUFFER_LIST, *PNET_BUFFER_LIST;
+
+    static std::vector<uint8_t> readNetBufferList(core::Core& core, uint64_t netBuffListAddress)
+    {
+        std::vector<uint8_t> invalid;
+
+        const auto reader = reader::make(core);
+        NET_BUFFER_LIST netBufferList;
+        NET_BUFFER      netBuffer;
+        MDL             mdl;
+        auto netBufferListsAddr = netBuffListAddress;
+        std::vector<uint8_t> data;
+
+        while(netBufferListsAddr)
+        {
+            auto ok = reader.read(&netBufferList, netBufferListsAddr, sizeof(netBufferList));
+            if(!ok)
+                return invalid;
+
+            netBufferListsAddr = (uint64_t) netBufferList.Next;
+
+            ok = reader.read(&netBuffer, (uint64_t) netBufferList.FirstNetBuffer, sizeof(netBuffer));
+            if(!ok)
+                return invalid;
+
+            uint32_t mdlOffset  = netBuffer.DataOffset;
+            uint32_t dataOffset = 0;
+            uint32_t dataSize   = netBuffer.stDataLength;
+            uint32_t size       = 0;
+            auto mdlAddress     = (uint64_t) netBuffer.CurrentMdl;
+
+            data.resize(data.size() + dataSize);
+            do
+            {
+                ok = reader.read(&mdl, mdlAddress, sizeof(mdl));
+                if(!ok)
+                    return invalid;
+                size = std::min(mdl.ByteCount - mdlOffset, dataSize);
+                ok   = reader.read(&data[dataOffset], (uint64_t) mdl.MappedSystemVa + mdlOffset, size);
+                if(!ok)
+                    return invalid;
+
+                dataSize -= size;
+                dataOffset += size;
+                mdlAddress = (uint64_t) mdl.Next;
+                mdlOffset  = 0;
+            } while(mdlAddress && dataSize);
+        }
+        return data;
+    }
+
+    static int capture(core::Core& core, std::string capture_path)
+    {
+        std::map<uint64_t, core::Breakpoint> user_bps;
+        pcap::FileWriterNG                   pcap;
+        sym::Loader kernel_sym(core);
+        uint64_t bp_id = 0;
+
+        const auto kernel_callstack = callstack::make_callstack_nt(core);
+        if(!kernel_callstack)
+            return -1;
+
+        const auto user_callstack = callstack::make_callstack_nt(core);
+        if(!user_callstack)
+            return -1;
+        //
+        // ndis!NdisSendNetBufferLists
+        //
+        const auto ndisCallSendHandler = kernel_sym.symbols().symbol("ndis", "NdisSendNetBufferLists");
+        if(!ndisCallSendHandler)
+            return FAIL(-1, "unable to set a BP on ndis!NdisSendNetBufferLists");
+
+        const auto bp_send = core.state.set_breakpoint("NdisSendNetBufferLists", *ndisCallSendHandler, [&]
+        {
+            const auto netBufferLists = core.os->read_arg(1);
+            const auto curProc        = core.os->proc_current();
+            const auto procName       = core.os->proc_name(*curProc);
+
+            const auto data = readNetBufferList(core, (*netBufferLists).val);
+
+            std::string comment(*procName);
+            comment += "(" + std::to_string(core.os->proc_id(*curProc));
+            comment += ")\n";
+            const auto packet = new pcap::Packet(data);
+            if(!packet)
+                return -1;
+            pcap.addPacket(packet);
+
+            auto time = std::chrono::high_resolution_clock::now();
+            packet->setTime(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count() / 1000);
+
+            LOG(INFO, " => {} bytes SENT", data.size());
+            bool bAddComment = false;
+            kernel_callstack->get_callstack(*curProc, [&](callstack::callstep_t callstep)
+            {
+                if(!core.os->is_kernel_address(callstep.addr))
+                {
+                    bAddComment = true;
+                    //
+                    // let's capture the user-callstack
+                    //
+                    struct Private
+                    {
+                        core::Core&                           core_;
+                        pcap::Packet*                         packet_;
+                        uint64_t                              id;
+                        std::map<uint64_t, core::Breakpoint>& bps;
+                    } p{core, packet, bp_id, user_bps};
+
+                    const auto bp   = core.state.set_breakpoint("NdisSendNetBufferLists user return", callstep.addr, [=]
+                    {
+                        auto comment = packet->getComment();
+                        p.bps.erase(p.id);
+                        const auto proc = p.core_.os->proc_current();
+                        // sym::Loader user_sym(p.core_, *proc);
+                        user_callstack->get_callstack(*proc, [&](callstack::callstep_t step)
+                        {
+                            LOG(INFO, "{:#x}", step.addr);
+                            /*
+                            const auto cursor = user_sym.symbols().find(step.addr);
+                            if(!cursor)
+                            {
+                                LOG(INFO, "{:#x}", step.addr);
+                                comment += std::to_string(step.addr);
+                            }
+                            else
+                            {
+                                LOG(INFO, "{}", sym::to_string(*cursor).data());
+                                comment += sym::to_string(*cursor).data();
+                                comment += "\n";
+                            }
+                            */
+                            return WALK_NEXT;
+                        });
+                        packet->setComment(comment);
+                        return 0;
+                    });
+                    user_bps[bp_id] = bp;
+                    bp_id++;
+                    return WALK_STOP;
+                }
+                const auto cursor = kernel_sym.symbols().find(callstep.addr);
+                if(!cursor)
+                {
+                    LOG(INFO, "{:#x}", callstep.addr);
+                    comment += std::to_string(callstep.addr);
+                }
+                else
+                {
+                    comment += sym::to_string(*cursor).data();
+                    comment += "\n";
+                    LOG(INFO, "{}", sym::to_string(*cursor).data());
+                }
+                return WALK_NEXT;
+            });
+            if(bAddComment)
+                packet->setComment(comment);
+            return 0;
+        });
+        //
+        // ndis!NdisReturnNetBufferLists
+        //
+        const auto NdisReturnNetBufferLists = kernel_sym.symbols().symbol("ndis", "NdisMIndicateReceiveNetBufferLists");
+        if(!NdisReturnNetBufferLists)
+            return FAIL(-1, "unable to et a BP on ndis!NdisMIndicateReceiveNetBufferLists");
+
+        const auto bp_recv = core.state.set_breakpoint("NdisMIndicateReceiveNetBufferLists", *NdisReturnNetBufferLists, [&]
+        {
+            const auto netBufferLists = core.os->read_arg(1);
+
+            const auto data      = readNetBufferList(core, (*netBufferLists).val);
+            pcap::Packet* packet = new pcap::Packet(data);
+            if(!packet)
+                return -1;
+            auto time = std::chrono::high_resolution_clock::now();
+            packet->setTime(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count() / 1000);
+            pcap.addPacket(packet);
+            LOG(INFO, " <= {} bytes RECEIVED", data.size());
+            return 0;
+        });
+
+        while(true)
+        {
+            core.state.resume();
+            core.state.wait();
+        }
+        pcap.write(capture_path.data());
+
+        return 0;
+    }
+}
+int main(int argc, char** argv)
+{
+    logg::init(argc, argv);
+    if(argc != 3)
+        return FAIL(-1, "usage: wireshark <name> <cpature file path>");
+
+    const auto name = std::string{argv[1]};
+    LOG(INFO, "starting on: {}", name.data());
+    const auto capture_path = std::string{argv[2]};
+    LOG(INFO, "capture path: {}", capture_path.data());
+
+    core::Core core;
+    const auto ok = core.setup(name);
+    if(!ok)
+    {
+        return FAIL(-1, "unable to start core at {}", name.data());
+    }
+
+    capture(core, capture_path);
+    //
+    // resume VM
+    //
+    core.state.pause();
+    core.state.resume();
+    return 0;
+}

--- a/src/icebox/samples/wireshark/main.cpp
+++ b/src/icebox/samples/wireshark/main.cpp
@@ -141,23 +141,24 @@ namespace
         if(!TEB_TlsSlots)
             return {};
 
-        const auto TlsSlot       = teb + *TEB_TlsSlots + 8 + 4; // FIXME: why +4 on 10240 ?
+        const auto TlsSlot       = teb + *TEB_TlsSlots + 8;
         const auto WOW64_CONTEXT = reader.read(TlsSlot);
         if(!WOW64_CONTEXT)
             return {};
         LOG(INFO, "TEB is: {:#x}, r12 is: {:#x}, r13 is: {:#x}", teb, TlsSlot, *WOW64_CONTEXT);
 
-        const auto off_ebp = offsetof(nt_types::_WOW64_CONTEXT, Ebp);
+        auto offset        = 4; // FIXME: why 4 on 10240 ?
+        const auto off_ebp = offsetof(nt_types::_WOW64_CONTEXT, Ebp) + offset;
         const auto ebp     = reader.le32(*WOW64_CONTEXT + off_ebp);
         if(!ebp)
             return {};
 
-        const auto off_eip = offsetof(nt_types::_WOW64_CONTEXT, Eip);
+        const auto off_eip = offsetof(nt_types::_WOW64_CONTEXT, Eip) + offset;
         const auto eip     = reader.le32(*WOW64_CONTEXT + off_eip);
         if(!eip)
             return {};
 
-        const auto off_esp = offsetof(nt_types::_WOW64_CONTEXT, Esp);
+        const auto off_esp = offsetof(nt_types::_WOW64_CONTEXT, Esp) + offset;
         const auto esp     = reader.le32(*WOW64_CONTEXT + off_esp);
         if(!esp)
             return {};

--- a/src/icebox/samples/wireshark/main.cpp
+++ b/src/icebox/samples/wireshark/main.cpp
@@ -16,39 +16,35 @@
 namespace
 {
 
-    typedef struct _MDL
+    struct MDL
     {
-        struct _MDL* Next;
-        uint16_t     Size;
-        uint16_t     MdlFlags;
-        void*        Process;
+        MDL*     Next;
+        uint16_t Size;
+        uint16_t MdlFlags;
+        void*    Process;
         void* MappedSystemVa; /* see creators for field size annotations. */
         void* StartVa;        /* see creators for validity; could be address 0.  */
         uint32_t ByteCount;
         uint32_t ByteOffset;
-    } MDL, *PMDL;
+    };
 
-    typedef struct _NET_BUFFER* PNET_BUFFER;
-
-    typedef struct _NET_BUFFER
+    struct NET_BUFFER
     {
-        PNET_BUFFER Next;
-        PMDL        CurrentMdl;
+        NET_BUFFER* Next;
+        MDL*        CurrentMdl;
         uint32_t    CurrentMdlOffset;
         uint32_t    reserved;
         uint32_t    stDataLength;
-        PMDL        MdlChain;
+        MDL*        MdlChain;
         uint32_t    DataOffset;
-    } NET_BUFFER, *PNET_BUFFER;
+    };
 
-    typedef struct _NET_BUFFER_LIST* PNET_BUFFER_LIST;
-
-    typedef struct _NET_BUFFER_LIST
+    struct NET_BUFFER_LIST
     {
-        PNET_BUFFER_LIST Next;           // Next NetBufferList in the chain
-        PNET_BUFFER      FirstNetBuffer; // First NetBuffer on this NetBufferList
+        NET_BUFFER_LIST* Next;           // Next NetBufferList in the chain
+        NET_BUFFER*      FirstNetBuffer; // First NetBuffer on this NetBufferList
         void*            Context;
-        PNET_BUFFER_LIST ParentNetBufferList;
+        NET_BUFFER_LIST* ParentNetBufferList;
         void*            NdisPoolHandle;
         void*            NdisReserved[2];
         void*            ProtocolReserved[4];
@@ -63,7 +59,7 @@ namespace
             uint32_t Status;
             uint32_t NdisReserved2;
         };
-    } NET_BUFFER_LIST, *PNET_BUFFER_LIST;
+    };
 
     static std::vector<uint8_t> read_NetBufferList(core::Core& core, uint64_t netBuffListAddress)
     {
@@ -229,7 +225,7 @@ namespace
         return comment;
     }
 
-    static void get_user_callstack32(core::Core& core, pcap::Packet& packet, proc_t proc, CallStack callstack)
+    static void get_user_callstack32(core::Core& core, pcap::Packet& packet, proc_t proc, const CallStack& callstack)
     {
         sym::Symbols symbols;
         load_proc_symbols(core, proc, symbols, FLAGS_32BIT);
@@ -245,7 +241,7 @@ namespace
         });
     }
 
-    static void get_user_callstack64(core::Core& core, pcap::Packet& packet, proc_t proc, CallStack callstack)
+    static void get_user_callstack64(core::Core& core, pcap::Packet& packet, proc_t proc, const CallStack& callstack)
     {
         sym::Symbols symbols;
         load_proc_symbols(core, proc, symbols, FLAGS_NONE);
@@ -257,7 +253,7 @@ namespace
         });
     }
 
-    static int capture(core::Core& core, std::string capture_path)
+    static int capture(core::Core& core, const std::string& capture_path)
     {
         std::map<int, core::Breakpoint> user_bps;
         pcap::FileWriterNG              pcap;

--- a/src/icebox/samples/wireshark/pcap.cpp
+++ b/src/icebox/samples/wireshark/pcap.cpp
@@ -1,76 +1,81 @@
 #include "pcap.hpp"
-#include <memory>
 
-struct BlockHeader
+#include <stdio.h>
+#include <vector>
+
+namespace
 {
-    uint32_t type;
-    uint32_t length;
-};
+    struct BlockHeader
+    {
+        uint32_t type;
+        uint32_t length;
+    };
 
-constexpr uint32_t typeSHB = 0x0A0D0D0A;
+    constexpr uint32_t typeSHB = 0x0A0D0D0A;
 
-struct SHB
-{
-    uint32_t byte_order;
-    uint16_t version_major; /* major version number */
-    uint16_t version_minor; /* minor version number */
-    int64_t section_length;
-};
+    struct SHB
+    {
+        uint32_t byte_order;
+        uint16_t version_major; /* major version number */
+        uint16_t version_minor; /* minor version number */
+        int64_t section_length;
+    };
 
-constexpr uint32_t typeEPB = 6;
+    constexpr uint32_t typeEPB = 6;
 
-struct EPB
-{
-    uint32_t if_id;
-    uint32_t timestamp_high;
-    uint32_t timestamp_low;
-    uint32_t cap_length;
-    uint32_t original_length;
-};
+    struct EPB
+    {
+        uint32_t if_id;
+        uint32_t timestamp_high;
+        uint32_t timestamp_low;
+        uint32_t cap_length;
+        uint32_t original_length;
+    };
 
-constexpr uint32_t typeIDB = 1;
+    constexpr uint32_t typeIDB = 1;
 
-struct IDB
-{
-    uint16_t link_type;
-    uint16_t reserved;
-    uint32_t snap_len;
-};
+    struct IDB
+    {
+        uint16_t link_type;
+        uint16_t reserved;
+        uint32_t snap_len;
+    };
 
-struct Option
-{
-    uint16_t code;
-    uint16_t length;
-};
-
-pcap::Packet::Packet(std::vector<uint8_t> d)
-{
-    data = d;
+    struct Option
+    {
+        uint16_t code;
+        uint16_t length;
+    };
 }
 
-pcap::Packet::~Packet()
+struct pcap::FileWriterNG::Data
+{
+    std::vector<pcap::Packet> packets;
+};
+
+pcap::FileWriterNG::FileWriterNG()
+    : d(std::make_unique<Data>())
 {
 }
 
-void pcap::Packet::setComment(std::string c)
+pcap::FileWriterNG::~FileWriterNG() = default;
+
+void pcap::FileWriterNG::add_packet(const pcap::Packet& p)
 {
-    comment = c;
+    d->packets.emplace_back(p);
 }
 
-constexpr uint32_t pcap_magic = 0xA1B2C3D4;
-
-bool pcap::FileWriterNG::write(const char* filePath)
+bool pcap::FileWriterNG::write(const char* filepath)
 {
-    file = fopen(filePath, "wb");
+    auto file = fopen(filepath, "wb");
     if(file == nullptr)
         return false;
-    //
+
     // Write the Section Header Block
-    //
     BlockHeader hdr;
     SHB         shb;
     hdr.type           = typeSHB;
-    hdr.length         = sizeof(BlockHeader) + sizeof(SHB) + sizeof(hdr.length);
+    hdr.length         = static_cast<uint32_t>(sizeof(BlockHeader) + sizeof(SHB) + sizeof(hdr.length));
     shb.byte_order     = 0x1a2b3c4d;
     shb.version_major  = 1;
     shb.version_minor  = 0;
@@ -85,12 +90,11 @@ bool pcap::FileWriterNG::write(const char* filePath)
     bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
     if(bytes != sizeof(hdr.length))
         return false;
-    //
+
     // IDB
-    //
     IDB idb;
     hdr.type      = typeIDB;
-    hdr.length    = sizeof(BlockHeader) + sizeof(IDB) + sizeof(hdr.length);
+    hdr.length    = static_cast<uint32_t>(sizeof(BlockHeader) + sizeof(IDB) + sizeof(hdr.length));
     idb.link_type = 1; // ETHERNET
     idb.reserved  = 0;
     idb.snap_len  = 0;
@@ -103,61 +107,64 @@ bool pcap::FileWriterNG::write(const char* filePath)
     bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
     if(bytes != sizeof(hdr.length))
         return false;
-    //
+
     // Write an Enhanced Packet Block for each packet
-    //
-    for(uint32_t i = 0; i < packets.size(); i++)
+    for(auto& p : d->packets)
     {
-        auto packet           = packets[i];
-        auto size             = packet->getDataLength();
+        auto size             = p.data.size();
         uint32_t optionLength = 0;
         uint32_t padding      = 0;
         if(size % 4)
             padding = 4 - (size % 4);
 
-        if(!packet->getComment().empty())
-        {
-            optionLength = 8 + (uint32_t) packet->getComment().size();
-        }
+        if(!p.meta.comment.empty())
+            optionLength = 8 + (uint32_t) p.meta.comment.size();
 
         EPB epb;
-        hdr.type   = typeEPB;
-        hdr.length = sizeof(BlockHeader) + sizeof(EPB) + sizeof(hdr.length) + size + padding + optionLength;
+        hdr.type = typeEPB;
+        if(sizeof(BlockHeader) + sizeof(EPB) + sizeof(hdr.length) + size + padding + optionLength > UINT32_MAX)
+            return false;
+
+        hdr.length = static_cast<uint32_t>(sizeof(BlockHeader) + sizeof(EPB) + sizeof(hdr.length) + size + padding + optionLength);
         bytes      = fwrite(&hdr, 1, sizeof(hdr), file);
         if(bytes != sizeof(hdr))
             return false;
 
-        auto timestamp = packet->getTimestamp();
+        auto timestamp = p.meta.timestamp;
         if(!timestamp)
-        {
-            timestamp = packet->getSeconds() * 1000000 + packet->getMicroSeconds();
-        }
-        epb.if_id           = 0;
-        epb.timestamp_high  = timestamp >> 32;
-        epb.timestamp_low   = timestamp & 0xFFFFFFFF;
-        epb.cap_length      = size;
-        epb.original_length = size;
+            timestamp = p.meta.sec * 1000000 + p.meta.usec;
+
+        epb.if_id          = 0;
+        epb.timestamp_high = timestamp >> 32;
+        epb.timestamp_low  = timestamp & 0xFFFFFFFF;
+        if(size > UINT32_MAX)
+            return false;
+
+        epb.cap_length      = static_cast<uint32_t>(size);
+        epb.original_length = static_cast<uint32_t>(size);
 
         bytes = fwrite(&epb, 1, sizeof(epb), file);
         if(bytes != sizeof(epb))
             return false;
-        bytes = fwrite(&packet->getData()[0], 1, size + padding, file);
+        auto packet_data = p.data;
+        bytes            = fwrite(&packet_data[0], 1, size + padding, file);
         if(bytes != size + padding)
             return false;
+
         // write comment option if any
-        if(!packet->getComment().empty())
+        if(!p.meta.comment.empty())
         {
             Option option;
             uint32_t paddingBuf = 0;
 
             option.code   = 1; // comment
-            option.length = (uint16_t) packet->getComment().size();
+            option.length = (uint16_t) p.meta.comment.size();
 
             bytes = fwrite(&option, 1, sizeof(option), file);
             if(bytes != sizeof(option))
                 return false;
 
-            bytes = fwrite(packet->getComment().c_str(), 1, option.length, file);
+            bytes = fwrite(p.meta.comment.c_str(), 1, option.length, file);
             if(bytes != option.length)
                 return false;
 
@@ -175,23 +182,11 @@ bool pcap::FileWriterNG::write(const char* filePath)
             if(bytes != sizeof(option))
                 return false;
         }
+
         bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
         if(bytes != sizeof(hdr.length))
             return false;
     }
     fclose(file);
     return true;
-}
-
-void pcap::FileWriterNG::addPacket(Packet* packet)
-{
-    packets.push_back(packet);
-}
-
-void pcap::FileWriterNG::addPackets(std::vector<pcap::Packet*> packet)
-{
-    for(uint32_t i = 0; i < packet.size(); i++)
-    {
-        addPacket(packet[i]);
-    }
 }

--- a/src/icebox/samples/wireshark/pcap.cpp
+++ b/src/icebox/samples/wireshark/pcap.cpp
@@ -1,0 +1,197 @@
+#include "pcap.hpp"
+#include <memory>
+
+struct BlockHeader
+{
+    uint32_t type;
+    uint32_t length;
+};
+
+constexpr uint32_t typeSHB = 0x0A0D0D0A;
+
+struct SHB
+{
+    uint32_t byte_order;
+    uint16_t version_major; /* major version number */
+    uint16_t version_minor; /* minor version number */
+    int64_t section_length;
+};
+
+constexpr uint32_t typeEPB = 6;
+
+struct EPB
+{
+    uint32_t if_id;
+    uint32_t timestamp_high;
+    uint32_t timestamp_low;
+    uint32_t cap_length;
+    uint32_t original_length;
+};
+
+constexpr uint32_t typeIDB = 1;
+
+struct IDB
+{
+    uint16_t link_type;
+    uint16_t reserved;
+    uint32_t snap_len;
+};
+
+struct Option
+{
+    uint16_t code;
+    uint16_t length;
+};
+
+pcap::Packet::Packet(std::vector<uint8_t> d)
+{
+    data = d;
+}
+
+pcap::Packet::~Packet()
+{
+}
+
+void pcap::Packet::setComment(std::string c)
+{
+    comment = c;
+}
+
+constexpr uint32_t pcap_magic = 0xA1B2C3D4;
+
+bool pcap::FileWriterNG::write(const char* filePath)
+{
+    file = fopen(filePath, "wb");
+    if(file == nullptr)
+        return false;
+    //
+    // Write the Section Header Block
+    //
+    BlockHeader hdr;
+    SHB         shb;
+    hdr.type           = typeSHB;
+    hdr.length         = sizeof(BlockHeader) + sizeof(SHB) + sizeof(hdr.length);
+    shb.byte_order     = 0x1a2b3c4d;
+    shb.version_major  = 1;
+    shb.version_minor  = 0;
+    shb.section_length = -1;
+
+    auto bytes = fwrite(&hdr, 1, sizeof(hdr), file);
+    if(bytes != sizeof(hdr))
+        return false;
+    bytes = fwrite(&shb, 1, sizeof(shb), file);
+    if(bytes != sizeof(shb))
+        return false;
+    bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
+    if(bytes != sizeof(hdr.length))
+        return false;
+    //
+    // IDB
+    //
+    IDB idb;
+    hdr.type      = typeIDB;
+    hdr.length    = sizeof(BlockHeader) + sizeof(IDB) + sizeof(hdr.length);
+    idb.link_type = 1; // ETHERNET
+    idb.reserved  = 0;
+    idb.snap_len  = 0;
+    bytes         = fwrite(&hdr, 1, sizeof(hdr), file);
+    if(bytes != sizeof(hdr))
+        return false;
+    bytes = fwrite(&idb, 1, sizeof(idb), file);
+    if(bytes != sizeof(idb))
+        return false;
+    bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
+    if(bytes != sizeof(hdr.length))
+        return false;
+    //
+    // Write an Enhanced Packet Block for each packet
+    //
+    for(uint32_t i = 0; i < packets.size(); i++)
+    {
+        auto packet           = packets[i];
+        auto size             = packet->getDataLength();
+        uint32_t optionLength = 0;
+        uint32_t padding      = 0;
+        if(size % 4)
+            padding = 4 - (size % 4);
+
+        if(!packet->getComment().empty())
+        {
+            optionLength = 8 + (uint32_t) packet->getComment().size();
+        }
+
+        EPB epb;
+        hdr.type   = typeEPB;
+        hdr.length = sizeof(BlockHeader) + sizeof(EPB) + sizeof(hdr.length) + size + padding + optionLength;
+        bytes      = fwrite(&hdr, 1, sizeof(hdr), file);
+        if(bytes != sizeof(hdr))
+            return false;
+
+        auto timestamp = packet->getTimestamp();
+        if(!timestamp)
+        {
+            timestamp = packet->getSeconds() * 1000000 + packet->getMicroSeconds();
+        }
+        epb.if_id           = 0;
+        epb.timestamp_high  = timestamp >> 32;
+        epb.timestamp_low   = timestamp & 0xFFFFFFFF;
+        epb.cap_length      = size;
+        epb.original_length = size;
+
+        bytes = fwrite(&epb, 1, sizeof(epb), file);
+        if(bytes != sizeof(epb))
+            return false;
+        bytes = fwrite(&packet->getData()[0], 1, size + padding, file);
+        if(bytes != size + padding)
+            return false;
+        // write comment option if any
+        if(!packet->getComment().empty())
+        {
+            Option option;
+            uint32_t paddingBuf = 0;
+
+            option.code   = 1; // comment
+            option.length = (uint16_t) packet->getComment().size();
+
+            bytes = fwrite(&option, 1, sizeof(option), file);
+            if(bytes != sizeof(option))
+                return false;
+
+            bytes = fwrite(packet->getComment().c_str(), 1, option.length, file);
+            if(bytes != option.length)
+                return false;
+
+            if(option.length % 4)
+            {
+                padding = 4 - (option.length % 4);
+                bytes   = fwrite(&paddingBuf, 1, padding, file);
+                if(bytes != padding)
+                    return false;
+            }
+            option.code   = 0;
+            option.length = 0;
+
+            bytes = fwrite(&option, 1, sizeof(option), file);
+            if(bytes != sizeof(option))
+                return false;
+        }
+        bytes = fwrite(&hdr.length, 1, sizeof(hdr.length), file);
+        if(bytes != sizeof(hdr.length))
+            return false;
+    }
+    fclose(file);
+    return true;
+}
+
+void pcap::FileWriterNG::addPacket(Packet* packet)
+{
+    packets.push_back(packet);
+}
+
+void pcap::FileWriterNG::addPackets(std::vector<pcap::Packet*> packet)
+{
+    for(uint32_t i = 0; i < packet.size(); i++)
+    {
+        addPacket(packet[i]);
+    }
+}

--- a/src/icebox/samples/wireshark/pcap.cpp
+++ b/src/icebox/samples/wireshark/pcap.cpp
@@ -1,6 +1,6 @@
 #include "pcap.hpp"
 
-#include <stdio.h>
+#include <cstdio>
 #include <vector>
 
 namespace
@@ -65,9 +65,9 @@ void pcap::FileWriterNG::add_packet(const pcap::Packet& p)
     d->packets.emplace_back(p);
 }
 
-bool pcap::FileWriterNG::write(const char* filepath)
+bool pcap::FileWriterNG::write(const std::string& filepath)
 {
-    auto file = fopen(filepath, "wb");
+    auto file = fopen(filepath.data(), "wb");
     if(file == nullptr)
         return false;
 

--- a/src/icebox/samples/wireshark/pcap.hpp
+++ b/src/icebox/samples/wireshark/pcap.hpp
@@ -7,7 +7,7 @@
 
 namespace pcap
 {
-    struct packet_metadata_t
+    struct metadata_t
     {
         uint32_t    if_id;
         uint64_t    timestamp;
@@ -16,18 +16,12 @@ namespace pcap
         std::string comment;
     };
 
-    struct Packet
+    struct Writer
     {
-        packet_metadata_t    meta;
-        std::vector<uint8_t> data;
-    };
+         Writer();
+        ~Writer();
 
-    struct FileWriterNG
-    {
-         FileWriterNG();
-        ~FileWriterNG();
-
-        void    add_packet  (const pcap::Packet& p);
+        void    add_packet  (const metadata_t& p, const void* data, size_t size);
         bool    write       (const std::string& filepath);
 
         struct Data;

--- a/src/icebox/samples/wireshark/pcap.hpp
+++ b/src/icebox/samples/wireshark/pcap.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+namespace pcap
+{
+
+    class Packet
+    {
+        std::vector<uint8_t> data;
+        uint32_t ifId      = 0;
+        uint64_t timestamp = 0;
+        uint32_t sec       = 0;
+        uint32_t usec      = 0;
+        std::string comment;
+
+      public:
+         Packet(std::vector<uint8_t> d);
+        ~Packet();
+        uint32_t getDataLength() { return (uint32_t) data.size(); }
+        std::vector<uint8_t> getData() { return data; }
+        uint32_t getSeconds() { return sec; }
+        uint32_t getMicroSeconds() { return usec; }
+        uint64_t getTimestamp() { return timestamp; }
+        std::string getComment() { return comment; }
+        void setComment(std::string c);
+        void setTime(uint64_t t) { timestamp = t; }
+        void setTime(uint32_t s, uint32_t u)
+        {
+            sec  = s;
+            usec = u;
+        }
+    };
+
+    class FileWriterNG
+    {
+        FILE* file = nullptr;
+        std::vector<Packet*> packets;
+
+      public:
+        FileWriterNG() {}
+        void    addPacket   (Packet* p);
+        void    addPackets  (std::vector<Packet*> packets);
+        uint32_t packetCount() { return (uint32_t) packets.size(); }
+        bool write(const char* filePath);
+    };
+} // namespace pcap

--- a/src/icebox/samples/wireshark/pcap.hpp
+++ b/src/icebox/samples/wireshark/pcap.hpp
@@ -9,7 +9,7 @@ namespace pcap
 {
     struct packet_metadata_t
     {
-        uint32_t    ifId;
+        uint32_t    if_id;
         uint64_t    timestamp;
         uint32_t    sec;
         uint32_t    usec;

--- a/src/icebox/samples/wireshark/pcap.hpp
+++ b/src/icebox/samples/wireshark/pcap.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -27,7 +28,7 @@ namespace pcap
         ~FileWriterNG();
 
         void    add_packet  (const pcap::Packet& p);
-        bool    write       (const char* filepath);
+        bool    write       (const std::string& filepath);
 
         struct Data;
         std::unique_ptr<Data> d;

--- a/src/icebox/samples/wireshark/pcap.hpp
+++ b/src/icebox/samples/wireshark/pcap.hpp
@@ -1,50 +1,35 @@
 #pragma once
 
 #include <stdint.h>
-#include <stdio.h>
 #include <string>
 #include <vector>
 
 namespace pcap
 {
-
-    class Packet
+    struct packet_metadata_t
     {
-        std::vector<uint8_t> data;
-        uint32_t ifId      = 0;
-        uint64_t timestamp = 0;
-        uint32_t sec       = 0;
-        uint32_t usec      = 0;
+        uint32_t    ifId;
+        uint64_t    timestamp;
+        uint32_t    sec;
+        uint32_t    usec;
         std::string comment;
-
-      public:
-         Packet(std::vector<uint8_t> d);
-        ~Packet();
-        uint32_t getDataLength() { return (uint32_t) data.size(); }
-        std::vector<uint8_t> getData() { return data; }
-        uint32_t getSeconds() { return sec; }
-        uint32_t getMicroSeconds() { return usec; }
-        uint64_t getTimestamp() { return timestamp; }
-        std::string getComment() { return comment; }
-        void setComment(std::string c);
-        void setTime(uint64_t t) { timestamp = t; }
-        void setTime(uint32_t s, uint32_t u)
-        {
-            sec  = s;
-            usec = u;
-        }
     };
 
-    class FileWriterNG
+    struct Packet
     {
-        FILE* file = nullptr;
-        std::vector<Packet*> packets;
+        packet_metadata_t    meta;
+        std::vector<uint8_t> data;
+    };
 
-      public:
-        FileWriterNG() {}
-        void    addPacket   (Packet* p);
-        void    addPackets  (std::vector<Packet*> packets);
-        uint32_t packetCount() { return (uint32_t) packets.size(); }
-        bool write(const char* filePath);
+    struct FileWriterNG
+    {
+         FileWriterNG();
+        ~FileWriterNG();
+
+        void    add_packet  (const pcap::Packet& p);
+        bool    write       (const char* filepath);
+
+        struct Data;
+        std::unique_ptr<Data> d;
     };
 } // namespace pcap


### PR DESCRIPTION
Wireshark plugin made for a demonstration. It traces send and receive on network at kernel level to create a wireshark trace (.pcapng). Support was added so that each packet sent is associated to a callstack from kernel land to user land if the send was made by a process user.