### PR TITLE
ninja-build is missing for apt

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -7,7 +7,8 @@ sudo apt install            \
             python3         \
             gcc-8           \
             g++-8           \
-            clang-format
+            clang-format    \
+            ninja-build
 ```
 
 *Note: the use of the command **update-alternatives** might be useful to set python3, gcc-8 and g++-8 as default*


### PR DESCRIPTION
Hello,

I'm testing IceBox on Debian 10.
Seems everything is working for now.
I just notice that ninja-build is missing from your BUILD.md instructions.

Thank you :)