### PR TITLE
add better support for linux profile creation

### DIFF
--- a/doc/make_profil_linux/make_profil.sh
+++ b/doc/make_profil_linux/make_profil.sh
@@ -16,7 +16,7 @@
 tmp=$(mktemp -dt)
 trap "rm -rf $tmp ; cd $PWD" 0
 
-version=`dmesg -t | grep "Linux version" | tr -d '\n'`
+version=`sudo dmesg -t | grep "Linux version" | tr -d '\n'`
 echo "Version of linux found : '$version'"
 
 hash=`printf '%s' "$version" | sha1sum | cut -c1-40`
@@ -28,7 +28,7 @@ make
 mv elf $wdir
 
 user_script=$USER
-sudo cp /boot/System.map-$(uname -r) $wdir/System.map
+sudo cp /boot/System.map-$(uname -r) $wdir/System.map || sudo cp /proc/kallsyms $wdir/System.map
 sudo chown $user_script:$user_script $wdir/System.map
 chmod 664 $wdir/System.map
 


### PR DESCRIPTION
Profile creation does not work on all Linux distributions out of the box. This PR attempt to make it work on more distributions with the following changes:
- run dmesg as root as depending on CONFIG_SECURITY_DMESG_RESTRICT it might not be possible to read kernel buffer for non-root
- if System.map is not found in /boot (some distributions such as ArchLinux don't provide a System.map), instead try getting it from procfs (requires root to get addresses non zeroed)

edit: ci failure seams unrelated to this patch